### PR TITLE
Optimize dashboard for Render deployment

### DIFF
--- a/translations.py
+++ b/translations.py
@@ -15,9 +15,7 @@ LANG = {
         "tab_country": "🌍 Trade by Country",
         "tab_product": "📦 Trade by Product",
         "tab_country_products": "🌍📦 Top Products per Country",
-        "tab_trend_hs": "📈 Trade Trend per Product",
-        "tab_treemap": "📂 Treemap",
-        "tab_sankey": "🌐 Sankey Trade Flow"
+        "tab_trend_hs": "📈 Trade Trend per Product"
     },
     "es": {
         "label_language": "Idioma:",
@@ -35,8 +33,6 @@ LANG = {
         "tab_country": "🌍 Comercio por país",
         "tab_product": "📦 Comercio por producto",
         "tab_country_products": "🌍📦 Productos principales por país",
-        "tab_trend_hs": "📈 Tendencia por producto",
-        "tab_treemap": "📂 Mapa de árbol",
-        "tab_sankey": "🌐 Flujo comercial Sankey"
+        "tab_trend_hs": "📈 Tendencia por producto"
     }
 }


### PR DESCRIPTION
## Summary
- streamline data filtering to reduce unnecessary copies and improve caching behaviour
- remove treemap and Sankey views to keep the Render deployment lightweight and adjust tab labels accordingly
- configure runtime debug mode via environment variable for production hosting

## Testing
- python -m compileall app.py translations.py

------
https://chatgpt.com/codex/tasks/task_e_68e2c29e895c8326995be74a1dd7f99a