### PR TITLE
Localize chart titles and axes

### DIFF
--- a/app.py
+++ b/app.py
@@ -319,11 +319,11 @@ def apply_standard_layout(fig, x_title="", y_title="", legend="horizontal", heig
     )
     return fig
 
-def build_empty_figure(title: str) -> go.Figure:
+def build_empty_figure(title: str, message: str) -> go.Figure:
     """Return a placeholder figure with a standard message."""
     fig = go.Figure()
     fig.add_annotation(
-        text="No data available for the current selection",
+        text=message,
         showarrow=False,
         font=dict(size=18),
         x=0.5,
@@ -566,6 +566,22 @@ def update_dashboard(year, country, hs_level, product, tab, lang):
     labels = LANG.get(lang, LANG["en"])  # fallback: englisch
     years = tuple(int(y) for y in year) if year else ()
 
+    flow_label_map = {
+        "Export": labels["flow_export"],
+        "Import": labels["flow_import"],
+    }
+    flow_color_map = {
+        labels["flow_export"]: GRAPH_STYLE["color_export"],
+        labels["flow_import"]: GRAPH_STYLE["color_import"],
+    }
+    legend_title_flow = labels["legend_flow"]
+    axis_year = labels["axis_year"]
+    axis_chf = labels["axis_chf"]
+    axis_country = labels["axis_country"]
+    axis_product = labels["axis_product"]
+    axis_tariff_code = labels["axis_tariff_code"]
+    no_data_message = labels["chart_no_data"]
+
     LOGGER.debug(
         "update_dashboard called | years=%s countries=%s hs_level=%s product_count=%s tab=%s lang=%s",
         years if years else "ALL",
@@ -592,7 +608,7 @@ def update_dashboard(year, country, hs_level, product, tab, lang):
     imp_sum = dff_year.loc[dff_year["Flow"] == "Import", "chf_num"].sum()
     balance, volume = exp_sum - imp_sum, exp_sum + imp_sum
     if not years:
-        year_label = "All years"
+        year_label = labels["label_all_years"]
     elif len(years) == 1:
         year_label = str(years[0])
     else:
@@ -671,9 +687,12 @@ def update_dashboard(year, country, hs_level, product, tab, lang):
             else:
                 dff_trend = dff_trend[dff_trend[hs_level].isin(product)]
 
+        country_label = ", ".join(country) if country else "LATAM"
+        chart_title = labels["chart_trade_volume_title"].format(location=country_label)
+
         if dff_trend.empty:
             LOGGER.warning("Trend dataset empty; returning placeholder figure")
-            trend_fig = build_empty_figure("📈 Trade Volume by Year")
+            trend_fig = build_empty_figure(chart_title, no_data_message)
         else:
             # Aggregation
             df_trend = dff_trend.groupby(["year", "Flow"])["chf_num"].sum().reset_index()
@@ -696,22 +715,19 @@ def update_dashboard(year, country, hs_level, product, tab, lang):
                     balance[col] = 0
             balance["Balance"] = balance["Export"] - balance["Import"]
 
-            # Länder-Label für Titel
-            country_label = ", ".join(country) if country else "LATAM"
+            df_trend["Flow_localized"] = df_trend["Flow"].map(flow_label_map).fillna(df_trend["Flow"])
 
             # 📊 Export + Import Balken
             fig = px.bar(
                 df_trend,
                 x="year",
                 y="chf_num",
-                color="Flow",
+                color="Flow_localized",
                 barmode="stack",
-                title=f"📈 Trade Volume by Year – {country_label}",
+                title=chart_title,
                 template=GRAPH_STYLE["template"],
-                color_discrete_map={
-                    "Export": GRAPH_STYLE["color_export"],
-                    "Import": GRAPH_STYLE["color_import"]
-                }
+                color_discrete_map=flow_color_map,
+                category_orders={"Flow_localized": [flow_label_map["Export"], flow_label_map["Import"]]}
             )
 
             # ➕ Balance-Linie
@@ -719,17 +735,24 @@ def update_dashboard(year, country, hs_level, product, tab, lang):
                 x=balance.index,
                 y=balance["Balance"],
                 mode="lines+markers+text",
-                name="Trade balance",
+                name=labels["chart_trade_volume_balance"],
                 line=dict(color=GRAPH_STYLE["color_trade"], width=5, dash="dot"),
                 marker=dict(size=12, symbol="circle"),
                 text=[human_format(v) for v in balance["Balance"]],
                 textposition="top center",
-                hovertemplate="<b>Year:</b> %{x}<br><b>Trade balance:</b> %{y:,.0f}<extra></extra>"
+                hovertemplate=(
+                    f"<b>{axis_year}:</b> %{{x}}<br>"
+                    f"<b>{labels['chart_trade_volume_balance']}:</b> %{{y:,.0f}}<extra></extra>"
+                )
             )
 
             # Hovertexte fix
             fig.update_traces(
-                hovertemplate="<b>Year:</b> %{x}<br><b>Flow:</b> %{fullData.name}<br><b>CHF:</b> %{y:,.0f}<extra></extra>",
+                hovertemplate=(
+                    f"<b>{axis_year}:</b> %{{x}}<br>"
+                    f"<b>{legend_title_flow}:</b> %{{fullData.name}}<br>"
+                    f"<b>{axis_chf}:</b> %{{y:,.0f}}<extra></extra>"
+                ),
                 selector=dict(type="bar")
             )
 
@@ -743,11 +766,11 @@ def update_dashboard(year, country, hs_level, product, tab, lang):
             # Layout
             trend_fig = apply_standard_layout(
                 fig,
-                x_title="Year",
-                y_title="CHF",
+                x_title=axis_year,
+                y_title=axis_chf,
                 legend="horizontal",
                 height=900,
-                legend_title="Flow"
+                legend_title=legend_title_flow
             )
 
         LOGGER.debug("Trend chart prepared for %d years", len(all_years))
@@ -773,9 +796,21 @@ def update_dashboard(year, country, hs_level, product, tab, lang):
         )
 
     elif tab == "country":
+        def format_years(values: tuple[int, ...]) -> str:
+            if not values:
+                return labels["label_all_years"]
+            years_sorted = sorted(values)
+            return ", ".join(str(y) for y in years_sorted)
+
+        years_label = format_years(years)
+        title_country = labels["chart_country_title"].format(
+            flow_info=labels["chart_country_flow_info"],
+            years=years_label,
+        )
+
         if dff_year.empty:
             LOGGER.warning("Country tab has no data; showing placeholder")
-            country_fig = build_empty_figure("🌍 Trade by Country")
+            country_fig = build_empty_figure(title_country, no_data_message)
         else:
             country_ranking = (
                 dff_year.groupby(["country_en", "Flow"])["chf_num"].sum().reset_index()
@@ -784,32 +819,35 @@ def update_dashboard(year, country, hs_level, product, tab, lang):
             top_countries = totals.sort_values("chf_num", ascending=False).head(25)["country_en"]
             country_ranking = country_ranking[country_ranking["country_en"].isin(top_countries)]
 
-            def format_years(years: list[int]) -> str:
-                """Format year selection for titles (explicit years)."""
-                if not years:
-                    return "All Years"
-                years_sorted = sorted(years)
-                return ", ".join(str(y) for y in years_sorted)
-
-            years_label = format_years(years)
+            country_ranking["Flow_localized"] = (
+                country_ranking["Flow"].map(flow_label_map).fillna(country_ranking["Flow"])
+            )
 
             fig = px.bar(
                 country_ranking, x="chf_num", y="country_en",
-                color="Flow", barmode="stack", orientation="h",
-                title=f"🌍 Trade by Country (Export + Import, {years_label})",
+                color="Flow_localized", barmode="stack", orientation="h",
+                title=title_country,
                 template=GRAPH_STYLE["template"],
-                color_discrete_map={
-                    "Export": GRAPH_STYLE["color_export"],
-                    "Import": GRAPH_STYLE["color_import"]
-                }
+                color_discrete_map=flow_color_map,
+                category_orders={"Flow_localized": [flow_label_map["Export"], flow_label_map["Import"]]}
             )
             fig.update_traces(
-
-                hovertemplate="<b>Country:</b> %{y}<br><b>Flow:</b> %{fullData.name}<br><b>CHF:</b> %{x:,.0f}<extra></extra>"
+                hovertemplate=(
+                    f"<b>{axis_country}:</b> %{{y}}<br>"
+                    f"<b>{legend_title_flow}:</b> %{{fullData.name}}<br>"
+                    f"<b>{axis_chf}:</b> %{{x:,.0f}}<extra></extra>"
+                )
             )
 
             fig.update_layout(yaxis=dict(categoryorder="total ascending"))
-            country_fig = apply_standard_layout(fig, x_title="CHF", y_title="Country", legend="horizontal", height=900)
+            country_fig = apply_standard_layout(
+                fig,
+                x_title=axis_chf,
+                y_title=axis_country,
+                legend="horizontal",
+                height=900,
+                legend_title=legend_title_flow,
+            )
             LOGGER.debug("Country chart prepared with %d countries", country_ranking['country_en'].nunique())
 
         content = html.Div(
@@ -839,7 +877,11 @@ def update_dashboard(year, country, hs_level, product, tab, lang):
 
         if dff_year.empty:
             LOGGER.warning("Product tab has no data; showing placeholder")
-            product_fig = build_empty_figure("📦 Trade by Product")
+            title_product = labels["chart_product_title"].format(
+                location=", ".join(country) if country else "LATAM",
+                years=labels["label_all_years"] if not years else ", ".join(str(y) for y in sorted(years)),
+            )
+            product_fig = build_empty_figure(title_product, no_data_message)
         else:
             # Aggregation nach Flow + HS-Level
             product_ranking = (
@@ -869,7 +911,11 @@ def update_dashboard(year, country, hs_level, product, tab, lang):
 
             if product_ranking.empty:
                 LOGGER.warning("No products remain after filtering; showing placeholder")
-                product_fig = build_empty_figure("📦 Trade by Product")
+                title_product = labels["chart_product_title"].format(
+                    location=", ".join(country) if country else "LATAM",
+                    years=labels["label_all_years"] if not years else ", ".join(str(y) for y in sorted(years)),
+                )
+                product_fig = build_empty_figure(title_product, no_data_message)
             else:
                 product_ranking["hs_label"] = (
                     product_ranking[code_col].astype(str) + " – " + product_ranking[desc_col].astype(str)
@@ -884,13 +930,13 @@ def update_dashboard(year, country, hs_level, product, tab, lang):
                 product_ranking["CHF_label"] = product_ranking["chf_num"].apply(human_format)
 
                 # Titel
-                def format_years(years: list[int]) -> str:
-                    if not years:
-                        return "All Years"
-                    years_sorted = sorted(years)
+                def format_years(selected_years: tuple[int, ...]) -> str:
+                    if not selected_years:
+                        return labels["label_all_years"]
+                    years_sorted = sorted(selected_years)
                     return ", ".join(str(y) for y in years_sorted)
 
-                def format_countries(countries: list[str]) -> str:
+                def format_countries(countries) -> str:
                     if not countries:
                         return "LATAM"
                     return ", ".join(countries)
@@ -898,17 +944,19 @@ def update_dashboard(year, country, hs_level, product, tab, lang):
                 years_label = format_years(years)
                 countries_label = format_countries(country)
 
+                product_ranking["Flow_localized"] = (
+                    product_ranking["Flow"].map(flow_label_map).fillna(product_ranking["Flow"])
+                )
+
                 # Plot
                 fig = px.bar(
                     product_ranking,
                     x="chf_num", y="hs_wrapped",
-                    color="Flow", orientation="h",
-                    title=f"📦 Trade by Product ({countries_label}, {years_label})",
+                    color="Flow_localized", orientation="h",
+                    title=labels["chart_product_title"].format(location=countries_label, years=years_label),
                     template=GRAPH_STYLE["template"],
-                    color_discrete_map={
-                        "Export": GRAPH_STYLE["color_export"],
-                        "Import": GRAPH_STYLE["color_import"]
-                    },
+                    color_discrete_map=flow_color_map,
+                    category_orders={"Flow_localized": [flow_label_map["Export"], flow_label_map["Import"]]},
                     text="CHF_label",
                     custom_data=[code_col, desc_col]   # für Hovertext
                 )
@@ -918,10 +966,10 @@ def update_dashboard(year, country, hs_level, product, tab, lang):
                     textposition="outside",
                     insidetextanchor="start",
                     hovertemplate=(
-                        "<b>Tariff code:</b> %{customdata[0]}<br>"
-                        "<b>Description:</b> %{customdata[1]}<br>"
-                        "<b>Flow:</b> %{fullData.name}<br>"
-                        "<b>CHF:</b> %{text}<extra></extra>"
+                        f"<b>{axis_tariff_code}:</b> %{{customdata[0]}}<br>"
+                        f"<b>{labels['label_description']}:</b> %{{customdata[1]}}<br>"
+                        f"<b>{legend_title_flow}:</b> %{{fullData.name}}<br>"
+                        f"<b>{axis_chf}:</b> %{{text}}<extra></extra>"
                     )
                 )
 
@@ -930,7 +978,14 @@ def update_dashboard(year, country, hs_level, product, tab, lang):
                     yaxis=dict(categoryorder="total ascending"),
                     margin=dict(l=400, r=80, t=80, b=80)
                 )
-                product_fig = apply_standard_layout(fig, x_title="CHF", y_title="Product", legend="horizontal", height=900)
+                product_fig = apply_standard_layout(
+                    fig,
+                    x_title=axis_chf,
+                    y_title=axis_product,
+                    legend="horizontal",
+                    height=900,
+                    legend_title=legend_title_flow,
+                )
                 LOGGER.debug("Product chart prepared with %d products", product_ranking[code_col].nunique())
 
         content = html.Div(
@@ -951,7 +1006,7 @@ def update_dashboard(year, country, hs_level, product, tab, lang):
     elif tab == "country_products":
         filter_row = html.Div([
             html.Label(
-                "Top Products:",
+                labels["country_products_top_label"],
                 style={
                     "marginLeft": "20px",
                     "fontFamily": "Arial",
@@ -961,7 +1016,7 @@ def update_dashboard(year, country, hs_level, product, tab, lang):
             ),
             dmc.Select(
                 id="country_products_topn",
-                data=[{"label": f"Top {n}", "value": str(n)} for n in [5, 10, 20, 25, 50, 100]],
+                data=[{"label": labels["top_n_option"].format(n=n), "value": str(n)} for n in [5, 10, 20, 25, 50, 100]],
                 value="5",    # 👉 String statt Int
                 clearable=False,
                 style={"width": 150}
@@ -992,14 +1047,21 @@ def update_dashboard(year, country, hs_level, product, tab, lang):
     Output("country_products_output", "children"),
     [Input("country", "value"),
      Input("year", "value"),
-     Input("country_products_topn", "value")]
+     Input("country_products_topn", "value"),
+     Input("language", "value")]
 )
 
 
-def update_country_products(selected_countries, years, top_n):
+def update_country_products(selected_countries, years, top_n, lang):
     years = tuple(int(y) for y in years) if years else ()
     top_n = int(top_n) if top_n else 5
+    if not lang:
+        lang = "en"
 
+    labels = LANG.get(lang, LANG["en"])
+    no_data_message = labels["chart_no_data"]
+    axis_product = labels["axis_product"]
+    axis_chf = labels["axis_chf"]
     LOGGER.debug(
         "update_country_products called | countries=%s years=%s top_n=%d",
         selected_countries if selected_countries else "ALL",
@@ -1013,7 +1075,7 @@ def update_country_products(selected_countries, years, top_n):
 
     if dff_tab.empty:
         return html.Div(
-            "No data available for the selected filters.",
+            no_data_message,
             style={"padding": "20px", "fontStyle": "italic"}
         )
 
@@ -1025,7 +1087,7 @@ def update_country_products(selected_countries, years, top_n):
 
     if data.empty:
         return html.Div(
-            "No data available after aggregation.",
+            no_data_message,
             style={"padding": "20px", "fontStyle": "italic"}
         )
 
@@ -1033,7 +1095,7 @@ def update_country_products(selected_countries, years, top_n):
 
     def format_years_label(values: tuple[int, ...]) -> str:
         if not values:
-            return "All years"
+            return labels["label_all_years"]
         if len(values) == 1:
             return str(values[0])
         return f"{min(values)}–{max(values)}"
@@ -1041,9 +1103,6 @@ def update_country_products(selected_countries, years, top_n):
     years_label = format_years_label(years)
     rows = []
     for c in countries:
-        col_export = dcc.Graph(figure=build_empty_figure(f"Top {top_n} Exports – {c} ({years_label})"))
-        col_import = dcc.Graph(figure=build_empty_figure(f"Top {top_n} Imports – {c} ({years_label})"))
-
         for flow in ["Export", "Import"]:
             df_flow = (
                 data[(data["country_en"] == c) & (data["Flow"] == flow)]
@@ -1051,17 +1110,23 @@ def update_country_products(selected_countries, years, top_n):
                 .copy()
             )
 
+            title_template = (
+                labels["chart_top_exports_title"]
+                if flow == "Export"
+                else labels["chart_top_imports_title"]
+            )
+            chart_title = title_template.format(top_n=top_n, country=c, years=years_label)
+
             if df_flow.empty:
                 LOGGER.debug("No %s data for country %s", flow, c)
-                fig = build_empty_figure(f"Top {top_n} {flow}s – {c} ({years_label})")
+                fig = build_empty_figure(chart_title, no_data_message)
             else:
                 df_flow["HS6_wrapped"] = df_flow["HS6_Description"].apply(lambda t: wrap_and_shorten(t, 30, 60))
-                title = f"Top {top_n} {flow}s – {c} ({years_label})"
                 fig = px.bar(
                     df_flow,
                     x="chf_num", y="HS6_wrapped",
                     orientation="h",
-                    title=title,
+                    title=chart_title,
                     template=GRAPH_STYLE["template"],
                     color_discrete_sequence=[
                         GRAPH_STYLE["color_export"] if flow == "Export" else GRAPH_STYLE["color_import"]
@@ -1073,19 +1138,25 @@ def update_country_products(selected_countries, years, top_n):
                     insidetextanchor="start",
                     cliponaxis=False,
                     hovertemplate=(
-                        "<b>Product:</b> %{y}<br>"
-                        "<b>CHF:</b> %{text}<extra></extra>"
+                        f"<b>{axis_product}:</b> %{{y}}<br>"
+                        f"<b>{axis_chf}:</b> %{{text}}<extra></extra>"
                     )
                 )
                 n_products = len(df_flow)
                 height = max(450, n_products * 40)
                 fig.update_layout(
-                    yaxis=dict(categoryorder="total ascending", title="Product"),
-                    xaxis=dict(title="CHF"),
+                    yaxis=dict(categoryorder="total ascending", title=axis_product),
+                    xaxis=dict(title=axis_chf),
                     margin=dict(l=250, r=50, t=80, b=50)
                 )
                 fig.update_yaxes(automargin=True, tickfont=dict(size=14))
-                fig = apply_standard_layout(fig, legend=False, height=height)
+                fig = apply_standard_layout(
+                    fig,
+                    x_title=axis_chf,
+                    y_title=axis_product,
+                    legend=False,
+                    height=height,
+                )
 
             graph_component = dcc.Graph(figure=fig)
             if flow == "Export":
@@ -1110,10 +1181,11 @@ def update_country_products(selected_countries, years, top_n):
     Output("trend_hs_content", "children"),
     [Input("country", "value"),
      Input("hs_level", "value"),
-     Input("tabs", "value")]
+     Input("tabs", "value"),
+     Input("language", "value")]
 )
 
-def update_trend_hs(country, hs_level, tab):
+def update_trend_hs(country, hs_level, tab, lang):
     if not hs_level or hs_level not in {
         "HS2_Description",
         "HS4_Description",
@@ -1121,18 +1193,24 @@ def update_trend_hs(country, hs_level, tab):
         "HS8_Description",
     }:
         hs_level = "HS6_Description"
+    if not lang:
+        lang = "en"
+    labels = LANG.get(lang, LANG["en"])
+    axis_year = labels["axis_year"]
+    axis_chf = labels["axis_chf"]
+    no_data_message = labels["chart_no_data"]
     LOGGER.debug("update_trend_hs called | countries=%s hs_level=%s", country if country else "ALL", hs_level)
 
     dff_hs = get_filtered_data(None, country, hs_level, None)
     log_dataframe_snapshot("Trend HS base", dff_hs)
 
     if dff_hs.empty:
-        empty = dcc.Graph(figure=build_empty_figure("📈 Trade Trend per Product"))
+        empty = dcc.Graph(figure=build_empty_figure(labels["chart_trade_trend_title"], no_data_message))
         return html.Div([empty], style={"padding": "20px"})
 
     all_years = dff_hs["year"].dropna().unique()
     if all_years.size == 0:
-        empty = dcc.Graph(figure=build_empty_figure("📈 Trade Trend per Product"))
+        empty = dcc.Graph(figure=build_empty_figure(labels["chart_trade_trend_title"], no_data_message))
         return html.Div([empty], style={"padding": "20px"})
 
     min_year, max_year = int(all_years.min()), int(all_years.max())
@@ -1144,16 +1222,17 @@ def update_trend_hs(country, hs_level, tab):
     )
 
     if trend_hs.empty:
-        empty = dcc.Graph(figure=build_empty_figure("📈 Trade Trend per Product"))
+        empty = dcc.Graph(figure=build_empty_figure(labels["chart_trade_trend_title"], no_data_message))
         return html.Div([empty], style={"padding": "20px"})
 
     hs_level_labels = {
-        "HS2_Description": "HS2 (2 digit)",
-        "HS4_Description": "HS4 (4 digit)",
-        "HS6_Description": "HS6 (6 digit)",
-        "HS8_Description": "HS8 (8 digit)",
+        "HS2_Description": labels["hs_level_label_HS2_Description"],
+        "HS4_Description": labels["hs_level_label_HS4_Description"],
+        "HS6_Description": labels["hs_level_label_HS6_Description"],
+        "HS8_Description": labels["hs_level_label_HS8_Description"],
     }
     level_label = hs_level_labels.get(hs_level, hs_level.replace("_Description", ""))
+    years_range_label = f"{min_year}–{max_year}"
 
     def shorten_text(t, max_len=50):
         if not isinstance(t, str):
@@ -1166,7 +1245,10 @@ def update_trend_hs(country, hs_level, tab):
     df_imp = trend_hs[trend_hs["Flow"] == "Import"]
 
     if df_exp.empty:
-        fig_exp = build_empty_figure(f"📈 Export Trend by {level_label} ({min_year}–{max_year})")
+        fig_exp = build_empty_figure(
+            labels["chart_export_trend_title"].format(level=level_label, years=years_range_label),
+            no_data_message,
+        )
         fig_exp.update_layout(height=900)
     else:
         fig_exp = px.line(
@@ -1175,21 +1257,30 @@ def update_trend_hs(country, hs_level, tab):
             color="hs_label",
             line_group="hs_label",
             markers=True,
-            title=f"📈 Export Trend by {level_label} ({min_year}–{max_year})",
+            title=labels["chart_export_trend_title"].format(level=level_label, years=years_range_label),
             template=GRAPH_STYLE["template"]
         )
         fig_exp.update_traces(
             marker=dict(size=10),
             hovertemplate=(
-                "<b>Year:</b> %{x}<br>"
-                "<b>Description:</b> %{fullData.name}<br>"
-                "<b>CHF:</b> %{y:,.0f}<extra></extra>"
+                f"<b>{axis_year}:</b> %{{x}}<br>"
+                f"<b>{labels['label_description']}:</b> %{{fullData.name}}<br>"
+                f"<b>{axis_chf}:</b> %{{y:,.0f}}<extra></extra>"
             )
         )
-        fig_exp = apply_standard_layout(fig_exp, "Year", "CHF", legend="bottom_full", height=900)
+        fig_exp = apply_standard_layout(
+            fig_exp,
+            axis_year,
+            axis_chf,
+            legend="bottom_full",
+            height=900,
+        )
 
     if df_imp.empty:
-        fig_imp = build_empty_figure(f"📈 Import Trend by {level_label} ({min_year}–{max_year})")
+        fig_imp = build_empty_figure(
+            labels["chart_import_trend_title"].format(level=level_label, years=years_range_label),
+            no_data_message,
+        )
         fig_imp.update_layout(height=900)
     else:
         fig_imp = px.line(
@@ -1198,18 +1289,24 @@ def update_trend_hs(country, hs_level, tab):
             color="hs_label",
             line_group="hs_label",
             markers=True,
-            title=f"📈 Import Trend by {level_label} ({min_year}–{max_year})",
+            title=labels["chart_import_trend_title"].format(level=level_label, years=years_range_label),
             template=GRAPH_STYLE["template"]
         )
         fig_imp.update_traces(
             marker=dict(size=10),
             hovertemplate=(
-                "<b>Year:</b> %{x}<br>"
-                "<b>Description:</b> %{fullData.name}<br>"
-                "<b>CHF:</b> %{y:,.0f}<extra></extra>"
+                f"<b>{axis_year}:</b> %{{x}}<br>"
+                f"<b>{labels['label_description']}:</b> %{{fullData.name}}<br>"
+                f"<b>{axis_chf}:</b> %{{y:,.0f}}<extra></extra>"
             )
         )
-        fig_imp = apply_standard_layout(fig_imp, "Year", "CHF", legend="bottom_full", height=900)
+        fig_imp = apply_standard_layout(
+            fig_imp,
+            axis_year,
+            axis_chf,
+            legend="bottom_full",
+            height=900,
+        )
 
     LOGGER.debug(
         "Trend HS charts prepared | export_traces=%d import_traces=%d",

--- a/translations.py
+++ b/translations.py
@@ -5,6 +5,7 @@ LANG = {
         "label_country": "Country(ies):",
         "label_hs_level": "Custom tariff level:",
         "label_description": "Description(s):",
+        "label_all_years": "All years",
 
         "kpi_exports": "Exports",
         "kpi_imports": "Imports",
@@ -17,7 +18,37 @@ LANG = {
         "tab_country_products": "🌍📦 Top Products per Country",
         "tab_trend_hs": "📈 Trade Trend per Product",
         "tab_treemap": "📂 Treemap",
-        "tab_sankey": "🌐 Sankey Trade Flow"
+        "tab_sankey": "🌐 Sankey Trade Flow",
+
+        "legend_flow": "Flow",
+        "axis_year": "Year",
+        "axis_chf": "CHF",
+        "axis_country": "Country",
+        "axis_product": "Product",
+        "axis_tariff_code": "Tariff code",
+
+        "flow_export": "Export",
+        "flow_import": "Import",
+
+        "chart_no_data": "No data available for the current selection",
+        "chart_trade_volume_title": "📈 Trade Volume by Year – {location}",
+        "chart_trade_volume_balance": "Trade balance",
+        "chart_country_title": "🌍 Trade by Country ({flow_info}, {years})",
+        "chart_country_flow_info": "Export + Import",
+        "chart_product_title": "📦 Trade by Product ({location}, {years})",
+        "chart_top_exports_title": "Top {top_n} Exports – {country} ({years})",
+        "chart_top_imports_title": "Top {top_n} Imports – {country} ({years})",
+        "chart_export_trend_title": "📈 Export Trend by {level} ({years})",
+        "chart_import_trend_title": "📈 Import Trend by {level} ({years})",
+        "chart_trade_trend_title": "📈 Trade Trend per Product",
+
+        "country_products_top_label": "Top Products:",
+        "top_n_option": "Top {n}",
+
+        "hs_level_label_HS2_Description": "HS2 (2 digit)",
+        "hs_level_label_HS4_Description": "HS4 (4 digit)",
+        "hs_level_label_HS6_Description": "HS6 (6 digit)",
+        "hs_level_label_HS8_Description": "HS8 (8 digit)"
     },
     "es": {
         "label_language": "Idioma:",
@@ -25,6 +56,7 @@ LANG = {
         "label_country": "País(es):",
         "label_hs_level": "Nivel arancelario:",
         "label_description": "Descripción(es):",
+        "label_all_years": "Todos los años",
 
         "kpi_exports": "Exportaciones",
         "kpi_imports": "Importaciones",
@@ -37,6 +69,36 @@ LANG = {
         "tab_country_products": "🌍📦 Productos principales por país",
         "tab_trend_hs": "📈 Tendencia por producto",
         "tab_treemap": "📂 Mapa de árbol",
-        "tab_sankey": "🌐 Flujo comercial Sankey"
+        "tab_sankey": "🌐 Flujo comercial Sankey",
+
+        "legend_flow": "Flujo",
+        "axis_year": "Año",
+        "axis_chf": "CHF",
+        "axis_country": "País",
+        "axis_product": "Producto",
+        "axis_tariff_code": "Código arancelario",
+
+        "flow_export": "Exportación",
+        "flow_import": "Importación",
+
+        "chart_no_data": "No hay datos disponibles para la selección actual",
+        "chart_trade_volume_title": "📈 Volumen comercial por año – {location}",
+        "chart_trade_volume_balance": "Balanza comercial",
+        "chart_country_title": "🌍 Comercio por país ({flow_info}, {years})",
+        "chart_country_flow_info": "Exportaciones + Importaciones",
+        "chart_product_title": "📦 Comercio por producto ({location}, {years})",
+        "chart_top_exports_title": "Principales {top_n} exportaciones – {country} ({years})",
+        "chart_top_imports_title": "Principales {top_n} importaciones – {country} ({years})",
+        "chart_export_trend_title": "📈 Tendencia de exportaciones por {level} ({years})",
+        "chart_import_trend_title": "📈 Tendencia de importaciones por {level} ({years})",
+        "chart_trade_trend_title": "📈 Tendencia comercial por producto",
+
+        "country_products_top_label": "Productos principales:",
+        "top_n_option": "Top {n}",
+
+        "hs_level_label_HS2_Description": "HS2 (2 dígitos)",
+        "hs_level_label_HS4_Description": "HS4 (4 dígitos)",
+        "hs_level_label_HS6_Description": "HS6 (6 dígitos)",
+        "hs_level_label_HS8_Description": "HS8 (8 dígitos)"
     }
 }


### PR DESCRIPTION
## Summary
- localize chart titles, axis labels, and legend entries across the dashboard based on the selected language
- add English and Spanish translation strings for the new chart text and reuse them in empty-state placeholders

## Testing
- python -m compileall .

------
https://chatgpt.com/codex/tasks/task_e_68e32d91a0748326bb0b9769e2190bdd